### PR TITLE
Add Flask example and deployment info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python virtual environments
+.venv/
+venv/
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+
+# macOS
+.DS_Store
+
+# Other
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # Prueba-GPT
+
+Este proyecto contiene un pequeño ejemplo de aplicación Flask.
+
+## Instalación
+
+1. Clona el repositorio y entra en la carpeta:
+   ```bash
+   git clone <URL_DEL_REPOSITORIO>
+   cd Prueba-GPT
+   ```
+2. Crea un entorno virtual e instala las dependencias:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+## Ejecutar la aplicación
+
+Para arrancar el servidor de desarrollo de Flask ejecuta:
+```bash
+python app.py
+```
+
+## Integración con Apache y mod_wsgi
+
+1. Asegúrate de tener instalado `mod_wsgi`.
+2. Copia el archivo `gamehub.wsgi` en el directorio del proyecto.
+3. Configura Apache añadiendo algo similar a lo siguiente en tu VirtualHost:
+   ```apache
+   WSGIDaemonProcess gamehub python-path=/ruta/al/proyecto/.venv/lib/python3.x/site-packages
+   WSGIProcessGroup gamehub
+   WSGIScriptAlias / /ruta/al/proyecto/gamehub.wsgi
+
+   <Directory /ruta/al/proyecto>
+       Require all granted
+   </Directory>
+   ```
+
+Al reiniciar Apache, la aplicación estará disponible usando `mod_wsgi`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return '¡Bienvenido a Game Hub!'
+
+if __name__ == '__main__':
+    app.run()

--- a/gamehub.wsgi
+++ b/gamehub.wsgi
@@ -1,0 +1,7 @@
+import sys
+import os
+
+# Adjust the path to make sure the application can be imported
+sys.path.insert(0, os.path.dirname(__file__))
+
+from app import app as application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+mysqlclient


### PR DESCRIPTION
## Summary
- flesh out README with virtualenv setup, running Flask and Apache `mod_wsgi`
- list dependencies in `requirements.txt`
- add a simple Flask `app.py`
- provide `gamehub.wsgi` for Apache
- ignore virtualenv and caches with `.gitignore`

## Testing
- `python -m py_compile app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f6258cf0832fb01b990d44eac4af