### PR TITLE
Add setup script for quick environment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python virtual environments
+.venv/
+venv/
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+
+# macOS
+.DS_Store
+
+# Other
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # Prueba-GPT
+
+Este proyecto contiene un pequeño ejemplo de aplicación Flask.
+
+## Instalación
+
+1. Clona el repositorio y entra en la carpeta:
+   ```bash
+   git clone <URL_DEL_REPOSITORIO>
+   cd Prueba-GPT
+   ```
+2. Crea un entorno virtual e instala las dependencias:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. De forma opcional puedes ejecutar el script `setup.sh` que automatiza la
+   creación del entorno virtual e instala las dependencias:
+   ```bash
+   bash setup.sh
+   ```
+
+## Ejecutar la aplicación
+
+Para arrancar el servidor de desarrollo de Flask ejecuta:
+```bash
+python app.py
+```
+
+## Integración con Apache y mod_wsgi
+
+1. Asegúrate de tener instalado `mod_wsgi`.
+2. Copia el archivo `gamehub.wsgi` en el directorio del proyecto.
+3. Configura Apache añadiendo algo similar a lo siguiente en tu VirtualHost:
+   ```apache
+   WSGIDaemonProcess gamehub python-path=/ruta/al/proyecto/.venv/lib/python3.x/site-packages
+   WSGIProcessGroup gamehub
+   WSGIScriptAlias / /ruta/al/proyecto/gamehub.wsgi
+
+   <Directory /ruta/al/proyecto>
+       Require all granted
+   </Directory>
+   ```
+
+Al reiniciar Apache, la aplicación estará disponible usando `mod_wsgi`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return '¡Bienvenido a Game Hub!'
+
+if __name__ == '__main__':
+    app.run()

--- a/gamehub.wsgi
+++ b/gamehub.wsgi
@@ -1,0 +1,7 @@
+import sys
+import os
+
+# Adjust the path to make sure the application can be imported
+sys.path.insert(0, os.path.dirname(__file__))
+
+from app import app as application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+mysqlclient

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Script de configuracion inicial para Game Hub
+# Crea el entorno virtual e instala las dependencias
+set -e
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Entorno configurado. Activa el entorno con 'source .venv/bin/activate' y ejecuta 'python app.py' para iniciar el servidor."


### PR DESCRIPTION
## Summary
- document optional use of `setup.sh`
- provide a simple bash setup script

## Testing
- `python -m py_compile app.py`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6862f6258cf0832fb01b990d44eac4af