### PR TITLE
Add gunicorn, Redis caching, and run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Prueba-GPT
 
 Este proyecto contiene un pequeño ejemplo de aplicación Flask.
+Incluye un sistema de caché basado en Redis mediante `Flask-Caching`.
 
 ## Instalación
 
@@ -27,6 +28,12 @@ Este proyecto contiene un pequeño ejemplo de aplicación Flask.
 Para arrancar el servidor de desarrollo de Flask ejecuta:
 ```bash
 python app.py
+```
+
+Si quieres ejecutar la aplicación en un entorno de producción de forma
+simple, puedes usar Gunicorn mediante el script incluido:
+```bash
+./run_gunicorn.sh
 ```
 
 ## Integración con Apache y mod_wsgi

--- a/app.py
+++ b/app.py
@@ -1,8 +1,16 @@
 from flask import Flask
+from flask_caching import Cache
 
 app = Flask(__name__)
+app.config.from_mapping({
+    "CACHE_TYPE": "RedisCache",
+    "CACHE_REDIS_HOST": "localhost",
+    "CACHE_REDIS_PORT": 6379,
+})
+cache = Cache(app)
 
 @app.route('/')
+@cache.cached(timeout=60)
 def home():
     return '¡Bienvenido a Game Hub!'
 

--- a/gamehub.py
+++ b/gamehub.py
@@ -1,0 +1,3 @@
+from app import app
+
+__all__ = ["app"]

--- a/gamehub.wsgi
+++ b/gamehub.wsgi
@@ -4,4 +4,4 @@ import os
 # Adjust the path to make sure the application can be imported
 sys.path.insert(0, os.path.dirname(__file__))
 
-from app import app as application
+from gamehub import app as application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Flask
 mysqlclient
+gunicorn
+Flask-Caching
+redis

--- a/run_gunicorn.sh
+++ b/run_gunicorn.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Ejecuta la aplicacion Game Hub usando Gunicorn
+exec gunicorn gamehub:app


### PR DESCRIPTION
## Summary
- add `gunicorn`, `Flask-Caching` and `redis` to dependencies
- configure Redis cache in the Flask app
- provide `run_gunicorn.sh` helper script
- expose the app as `gamehub:app` for Gunicorn and update wsgi file
- document caching and Gunicorn usage in README

## Testing
- `python -m py_compile app.py gamehub.py`
- `bash -n run_gunicorn.sh`
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686309c2ff88832f9be673b2367db7e7