### PR TITLE
Add JWT-protected API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ python app.py
     ```
 
 Al reiniciar Apache, la aplicación estará disponible usando `mod_wsgi`.
+
+## API con JWT
+
+La aplicación incluye un pequeño API bajo el prefijo `/api` que permite listar,
+crear, actualizar y eliminar juegos. Todas las rutas están protegidas con
+JSON Web Tokens.
+
+Para obtener un token envía una petición `POST` a `/login` con las claves
+`username` y `password` (por defecto `admin`/`password`). El token devuelto se
+usa en la cabecera `Authorization` con el formato `Bearer <token>` para acceder
+a las rutas protegidas.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,26 @@
-from flask import Flask
+from flask import Flask, jsonify, request
+from flask_jwt_extended import JWTManager, create_access_token
+
+from game_api import api_bp
 
 app = Flask(__name__)
+app.config['JWT_SECRET_KEY'] = 'change-this-secret'
+
+jwt = JWTManager(app)
+app.register_blueprint(api_bp)
 
 @app.route('/')
 def home():
     return '¡Bienvenido a Game Hub!'
+
+@app.route('/login', methods=['POST'])
+def login():
+    username = request.json.get('username')
+    password = request.json.get('password')
+    if username == 'admin' and password == 'password':
+        token = create_access_token(identity=username)
+        return jsonify(access_token=token)
+    return jsonify({'error': 'Bad credentials'}), 401
 
 if __name__ == '__main__':
     app.run()

--- a/game_api/__init__.py
+++ b/game_api/__init__.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+games = []
+
+@api_bp.route('/games', methods=['GET'])
+@jwt_required()
+def list_games():
+    return jsonify(games)
+
+@api_bp.route('/games', methods=['POST'])
+@jwt_required()
+def create_game():
+    data = request.get_json() or {}
+    game = {'id': len(games) + 1, 'name': data.get('name')}
+    games.append(game)
+    return jsonify(game), 201
+
+@api_bp.route('/games/<int:game_id>', methods=['PUT'])
+@jwt_required()
+def update_game(game_id):
+    data = request.get_json() or {}
+    for game in games:
+        if game['id'] == game_id:
+            game['name'] = data.get('name', game['name'])
+            return jsonify(game)
+    return jsonify({'error': 'Game not found'}), 404
+
+@api_bp.route('/games/<int:game_id>', methods=['DELETE'])
+@jwt_required()
+def delete_game(game_id):
+    for game in games:
+        if game['id'] == game_id:
+            games.remove(game)
+            return '', 204
+    return jsonify({'error': 'Game not found'}), 404

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 mysqlclient
+Flask-JWT-Extended


### PR DESCRIPTION
## Summary
- add a new Blueprint with CRUD routes for games
- secure API with Flask-JWT-Extended and provide login endpoint
- document usage of the new JWT-protected API
- include Flask-JWT-Extended in requirements

## Testing
- `python -m py_compile app.py game_api/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_686309be3800832f8e11de11f9de62fc