### PR TITLE
Implement env-controlled debug and remove extra Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Para arrancar el servidor de desarrollo de Flask ejecuta:
 python app.py
 ```
 
+El modo de depuración se controla mediante la variable de entorno
+`DEBUG`. Si se establece a `1`, `true` o `yes` la aplicación se ejecutará
+en modo debug. De lo contrario, la depuración estará desactivada.
+
 Si quieres ejecutar la aplicación en un entorno de producción de forma
 simple, puedes usar Gunicorn mediante el script incluido:
 ```bash
@@ -38,6 +42,8 @@ simple, puedes usar Gunicorn mediante el script incluido:
 En un entorno de producción es recomendable definir las variables de entorno
 `SECRET_KEY` y `JWT_SECRET_KEY` con valores propios para asegurar las claves
 de la aplicación y de los tokens JWT.
+El archivo `gamehub/config.py` también toma `SECRET_KEY` del entorno en caso
+de que se use su clase `Config` en otras configuraciones.
 
 ## Base de datos
 

--- a/app.py
+++ b/app.py
@@ -75,6 +75,12 @@ with app.app_context():
 app.register_blueprint(api_bp)
 
 
+@app.route('/')
+def home():
+    """Simple greeting for the root path."""
+    return '¡Bienvenido a Game Hub!'
+
+
 @app.route('/games', methods=['GET'])
 @jwt_required()
 def games_list():
@@ -224,4 +230,6 @@ def delete_game(gid):
     return '', 404
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_env = os.getenv('DEBUG', '')
+    debug_mode = debug_env.lower() in ('1', 'true', 'yes')
+    app.run(debug=debug_mode)

--- a/gamehub/__init__.py
+++ b/gamehub/__init__.py
@@ -1,6 +1,8 @@
-from flask import Flask
+"""Game Hub package.
 
-app = Flask(__name__)
-app.config.from_object('gamehub.config.Config')
+Provides database models, forms and configuration helpers.
+Previously this module created a Flask application instance and
+registered a single route. That functionality has moved to ``app.py``
+to avoid having two Flask objects.
+"""
 
-from . import routes  # noqa: E402

--- a/gamehub/config.py
+++ b/gamehub/config.py
@@ -1,2 +1,7 @@
+import os
+
+
 class Config:
-    SECRET_KEY = 'dev'
+    """Configuration values loaded from environment variables."""
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev")

--- a/gamehub/routes.py
+++ b/gamehub/routes.py
@@ -1,5 +1,0 @@
-from . import app
-
-@app.route('/')
-def home():
-    return '¡Bienvenido a Game Hub!'


### PR DESCRIPTION
## Summary
- configure Flask `app.run` to use `DEBUG` env var
- integrate the home route in `app.py`
- remove the unused secondary Flask instance
- load `SECRET_KEY` from the environment in `Config`
- document `DEBUG` env var and configuration changes in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643baf54c4832f9fe66b7a64ddf83e