### PR TITLE
Add search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ crear o eliminar juegos tanto en el API como en las vistas web.
 ## Formularios Web
 
 Se incluye una interfaz basada en Flask-WTF para crear y editar juegos desde la web. Las plantillas utilizan Bootstrap para el estilo y requieren un token JWT en la cabecera `Authorization` como el resto de las rutas.
+
+## Búsqueda de juegos
+
+La ruta `/games/search` permite obtener un listado filtrado en formato JSON. Puedes utilizar los parámetros `q` para buscar por nombre y `genre` para filtrar por género. Por ejemplo:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+    "http://localhost:5000/games/search?q=tetris&genre=Puzzle"
+```

--- a/app.py
+++ b/app.py
@@ -89,6 +89,21 @@ def games_list():
     return render_template('games.html', games=games, is_admin=admin_required())
 
 
+@app.route('/games/search', methods=['GET'])
+@jwt_required()
+def search_games():
+    """Return games filtered by optional query params."""
+    q = request.args.get('q')
+    genre = request.args.get('genre')
+    query = Game.query
+    if q:
+        query = query.filter(Game.name.ilike(f'%{q}%'))
+    if genre:
+        query = query.filter(Game.genre.ilike(f'%{genre}%'))
+    games = query.all()
+    return jsonify([g.to_dict() for g in games])
+
+
 @app.route('/register', methods=['POST'])
 def register():
     """Create a new user account."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,3 +129,23 @@ def test_requires_auth(client):
     assert r.status_code == 401
     r = client.delete("/games/1")
     assert r.status_code == 401
+
+
+def test_search_games(client):
+    token = login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    client.post(
+        "/games",
+        json={"name": "Tetris", "genre": "Puzzle"},
+        headers=headers,
+    )
+    client.post(
+        "/games",
+        json={"name": "Doom", "genre": "Action"},
+        headers=headers,
+    )
+    r = client.get("/games/search?q=tet", headers=headers)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Tetris"


### PR DESCRIPTION
## Summary
- implement `/games/search` endpoint with query parameters
- document game search functionality in README
- test game search

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643f610274832f8eb1c3b99a9db386